### PR TITLE
Add instructions for using when embedded in Spring Boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,28 @@ Note: Trying out the plugins with Camunda Platform 7.15.0 Docker image is more c
 Use it
 ------
 
+###Spring Boot
+
+Copy `config.js` and the files it references to `./src/main/resources/META-INF/resources/webjars/camunda/app/cockpit/scripts`. Once you are done, your project structure should look like this:
+```shell
+src/main/resources/
+├── META-INF
+│   ├── resources
+│   │   └── webjars
+│   │       └── camunda
+│   │           └── app
+│   │               └── cockpit
+│   │                   └── scripts
+│   │                       ├── config.js
+│   │                       ├── definition-historic-activities.js
+│   │                       ├── instance-historic-activities.js
+│   │                       ├── instance-route-history.js
+│   │                       └── robot-module.js
+```
+After this you can start the project and the plugin should be loaded. Usually, you customize config.js per project and define there which plugins are included and where the browser should find them. You may use a browser network inspector to check that Cockpit loads your version of config.js and also the plugin JavaScript files get loaded.
+
+###Other Distributions
+
 [Check the forum discussion on how to package plugins for various alternative Camunda distributions.](https://forum.camunda.org/t/minimal-cockpit-history-plugins-for-camunda-7-14-0/24651)
 
 


### PR DESCRIPTION
This plugin gets extensively used when Camunda
is embedded into the Spring Boot application.

Although the project has existed for quite some time, new
users are still struggling to use it with Spring Boot since
searching forums and GitHub issues is not the optimal way.

This commit adds instructions for new Spring Boot users
so that they can quickly use the plugin, addressing
GitHub issues #30, #24, #15, #8, and #7.