### PR TITLE
Got rid of maxResults for History tab, use pagination instead.

### DIFF
--- a/src/Components/PageLink.tsx
+++ b/src/Components/PageLink.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+interface Props {
+    label: string;
+    page: number;
+    isActive: boolean;
+    isDisabled: boolean;
+    onPage: (page: number) => any;
+}
+
+const PageLink: React.FC<Props> = ({ label, page, isDisabled, isActive, onPage }) => {
+
+    const pageClicked = (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>, page: number) => {
+        e.preventDefault();
+        if (!isDisabled) {
+            onPage(page);
+        }
+    }
+
+    return (
+        <li role="menuitem" className={`pagination-page ${isActive ? "active" : ""} ${isDisabled ? "disabled" : ""}`} key={label}>
+            <a href="#" className={isDisabled ? "disabled" : ""} onClick={(e) => pageClicked(e, page)}>{label}</a>
+        </li>
+    );
+};
+
+export default PageLink;

--- a/src/Components/Pagination.tsx
+++ b/src/Components/Pagination.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import PageLink from "./PageLink";
+
+interface Props {
+    currentPage: number;
+    perPage: number;
+    total: number;
+    showPages?: number;
+    onPage: (firstResult: number, page: number) => any;
+}
+
+const Pagination: React.FC<Props> = ({ currentPage, total, perPage, onPage, showPages = 7 }) => {
+
+    const range = (start: number, end: number) => {
+        let length = end - start + 1;
+        return Array.from({ length }, (_, idx) => idx + start);
+    };
+
+    const pageCount = React.useMemo(() => {
+        return Math.ceil(total / perPage);
+    }, [total, perPage]) as number;
+
+    const paginationRange = React.useMemo(() => {
+        if (pageCount < showPages) {
+            return range(1, pageCount);
+        }
+
+        if (currentPage > pageCount - Math.floor(showPages / 2)) {
+            return range((pageCount - showPages)+1, pageCount);
+        }
+
+        if (currentPage > Math.floor(showPages / 2)) {
+            return range(currentPage - Math.floor(showPages / 2), currentPage + Math.floor(showPages / 2));
+        }
+
+        return range(1, showPages);
+
+    }, [total, perPage, showPages, currentPage, pageCount]);
+
+    const pageClicked = (page: number) => {
+        onPage((page - 1) * perPage, page);
+    }
+
+    return (
+        <nav>
+            {pageCount > 1 && <ul className="pagination-sm pagination" role="menu">
+                <PageLink label="First" page={1} isActive={false} isDisabled={currentPage === 1} onPage={pageClicked} />
+                <PageLink label="Previous" page={currentPage-1} isActive={false} isDisabled={currentPage === 1} onPage={pageClicked} />
+                {paginationRange!.map(page => (
+                    <PageLink label={`${page}`} page={page} isActive={currentPage === page} isDisabled={false} onPage={pageClicked} />
+                ))}
+                <PageLink label="Next" page={currentPage+1} isActive={false} isDisabled={currentPage === pageCount} onPage={pageClicked} />
+                <PageLink label="Last" page={pageCount} isActive={false} isDisabled={currentPage === pageCount} onPage={pageClicked} />
+            </ul>}
+        </nav>
+    );
+};
+
+export default Pagination;


### PR DESCRIPTION
This pull request introduces pagination to the History tab, this way you have access to all historic process instances all the time.